### PR TITLE
fix: remove avatars from correct bucket

### DIFF
--- a/my-project-backend/src/main/java/com/example/service/impl/ImageServiceImpl.java
+++ b/my-project-backend/src/main/java/com/example/service/impl/ImageServiceImpl.java
@@ -96,7 +96,7 @@ public class ImageServiceImpl extends ServiceImpl<ImageStoreMapper, StoreImage> 
     private void deleteOldAvatar(String avatar) throws Exception {
         if (avatar == null || avatar.isEmpty()){return;}
         RemoveObjectArgs remove = RemoveObjectArgs.builder()
-                .bucket("test")
+                .bucket("study")
                 .object(avatar)
                 .build();
         client.removeObject(remove);


### PR DESCRIPTION
## Summary
- ensure old avatars are removed from MinIO `study` bucket when uploading new ones

## Testing
- `bash mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ea16c3a4832f8c377d2feb8eab34